### PR TITLE
Adapt booster to work whether TLS is enabled or not

### DIFF
--- a/greeting-service/src/main/fabric8/deployment.yml
+++ b/greeting-service/src/main/fabric8/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - livenessProbe:
+          failureThreshold: 2
+          initialDelaySeconds: 60
+          periodSeconds: 3
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health

--- a/name-service/src/main/fabric8/deployment.yml
+++ b/name-service/src/main/fabric8/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - livenessProbe:
+          failureThreshold: 2
+          initialDelaySeconds: 60
+          periodSeconds: 3
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreashold: 1
+          timeoutSeconds: 1
+          exec:
+            command:
+            - curl
+            - http://localhost:8080/health

--- a/pom.xml
+++ b/pom.xml
@@ -160,12 +160,6 @@
                       <value>true</value>
                     </property>
                   </deployment>
-                  <service>
-                    <property>
-                      <name>auth.istio.io/8080</name>
-                      <value>NONE</value>
-                    </property>
-                  </service>
                 </annotations>
               </resources>
             </configuration>


### PR DESCRIPTION

The booster already did this before, but Istio TLS has changes which is
why the application now needed to be adapted